### PR TITLE
Dockerfile: using swift-ubuntu:3.1 image instead of the latest one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibmcom/kitura-ubuntu:latest
+FROM ibmcom/swift-ubuntu:3.1
 
 MAINTAINER Jarrod Parkes <jarrod@udacity.com>
 


### PR DESCRIPTION
Latest image from Kitura doesn't have lCOpenSSL. swift-ubuntu image was used in the Monolith sample app and works fine.

Fixes #1.